### PR TITLE
Only patch npm packages for main package build and not for installs of the ckeditor-buils package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.4.1",
   "description": "Custom CKEditor builds",
   "scripts": {
-    "build": "webpack --mode=production",
-    "postinstall": "patch-package"
+    "build": "patch-package && webpack --mode=production"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
postinstall haakt ook in op het postinstall event van in een project, maar daar is de patch-packages geen dependency. Dus als we dit enkel voor de build in dit package runnen is het voldoende